### PR TITLE
Mission Complete.

### DIFF
--- a/pythonpath/org/openoffice/comp/addin/sample/python/getrest.py
+++ b/pythonpath/org/openoffice/comp/addin/sample/python/getrest.py
@@ -28,19 +28,16 @@ class GetRest( unohelper.Base, XGetRest,  XAddIn, XServiceName ):
     def getFunctionDescription( self , aProgrammaticName ):
         return "Get JSON Data from REST API"
 
-    def getDisplayArgumentName( self, aProgrammaticFunctionName, nArgument ):
-        return "Text"
-
     def getArgumentDescription( self, aProgrammaticFunctionName, nArgument ):
-        return "Get JSON Data from REST API"
+        return "URL of REST server"
     
     def getProgrammaticCategoryName( self, aProgrammaticFunctionName ):
         return "Add-In"
 
-    def getDisplayArgumentName( self, aProgrammaticFunctionName ):
-        return "Add-In"
+    def getDisplayArgumentName( self, aProgrammaticFunctionName, nArgument ):
+        return "URL string"
 
-    def getrest(self,url) -> str:
+    def GetRest(self, url) -> str:
         """
         Get JSON Data from REST API
         :rtype:object


### PR DESCRIPTION
こんばんわですー。LibreOffice Kaigi 2018 でお隣にいた英語のボロかった人です。

モノホンのSEに対して修正の意味を述べるのは釈迦に説法、無粋というものでありましょう。
…と書きつつちょっと補足。

- もしかしたら getrest.py をあんなに深いところに置かなくてはならないのは、idlにそう書いたから、かもしれません。試してませんけど。
- livedoorの天気予報はJSON、つまり元となったJavascriptの文法に基づき初めからエスケープしてありますなー。iso-8859-1 ではなくて US-ASCII ではない文字すべて、という感覚でしょうか。んで、Java版のはエスケープを処理せずにそのまま返してきていたと。Python様サマ、といったところですね。

ちなみに私がtokencounterの設置に失敗した理由はよくわからなかったのですが、どうもp--qさんのブログのどっかに書いてあった「圧縮対象を正しいモノではなく親フォルダにしてしまった」のが関係ありそうです。

